### PR TITLE
Fixing issue with node.js version 0.6 with missing fs.exists method

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,6 +48,7 @@ var server = http.createServer(function (req, res) {
       }
     }
 
+    fs.exists = fs.exists || require('path').exists;
     fs.exists(fileName, function (exists) {
       if (exists) {
         var readCache = fs.createReadStream(fileName);


### PR DESCRIPTION
Seems worthwhile supporting 0.6 despite users able to update to 0.6+ I had not even realised all this time I was using such an old version which is a default in Ubuntu still.
