### PR TITLE
Add missing dependency on async

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "sonos-discovery": "https://github.com/jishi/node-sonos-discovery/archive/0.15.3.tar.gz",
     "node-static": "0.7.x",
-    "socket.io": "0.9.x"
+    "socket.io": "0.9.x",
+    "async": "0.9.x"
   },
   "engine": "node 0.8.x"
 }


### PR DESCRIPTION
Blows up otherwise with:

```
module.js:340
    throw err;
          ^
Error: Cannot find module 'async'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/sonos-web/server.js:7:13)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
```