### PR TITLE
Make all requests relative to current location

### DIFF
--- a/static/dashboard/index.html
+++ b/static/dashboard/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<link rel="stylesheet" type="text/css" href="dashboard.css" />
 		<link href='http://fonts.googleapis.com/css?family=Roboto:300,500,900,700&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
-		<script src="/socket.io/socket.io.js"></script>
+		<script src="socket.io/socket.io.js"></script>
 		<script>
 		  var socket = io.connect('/');
 		</script>

--- a/static/index.html
+++ b/static/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<link rel="stylesheet" type="text/css" href="css/common.css" />
 		<link rel="stylesheet" type="text/css" href="css/main.css" />
-		<script src="/socket.io/socket.io.js"></script>
+		<script src="socket.io/socket.io.js"></script>
 		<script>
 
 		</script>

--- a/static/js/all.js
+++ b/static/js/all.js
@@ -54,15 +54,16 @@ function updateCurrentStatus() {
 
 	document.getElementById('page-title').textContent = selectedZone.state.currentTrack.title + ' - Sonos Web Controller';
 
+	var prefix = (window.location.pathname != '/') ? window.location.pathname : ''
 	if (selectedZone.state.currentTrack.type == 'radio') {
 		// update radio
-		document.getElementById("current-radio-art").src = selectedZone.state.currentTrack.albumArtURI;
+		document.getElementById("current-radio-art").src = prefix + selectedZone.state.currentTrack.albumArtURI;
 		document.getElementById("station").textContent = selectedZone.state.currentTrack.title;
 		document.getElementById("information").textContent = selectedZone.state.currentTrack.streamInfo;
 		document.getElementById("status-container").className = "radio";
 
 	} else {
-		document.getElementById("current-track-art").src =  selectedZone.state.currentTrack.albumArtURI;
+		document.getElementById("current-track-art").src = prefix + selectedZone.state.currentTrack.albumArtURI;
 		document.getElementById("track").textContent = selectedZone.state.currentTrack.title;
 		document.getElementById("artist").textContent = selectedZone.state.currentTrack.artist;
 		document.getElementById("album").textContent = selectedZone.state.currentTrack.album;
@@ -120,9 +121,9 @@ function updateControllerState() {
 	// fix mute
 	var masterMute = document.getElementById('master-mute');
 	if (currentZone.groupState.mute) {
-		masterMute.src = "/svg/mute_on.svg";
+		masterMute.src = "svg/mute_on.svg";
 	} else {
-		masterMute.src = "/svg/mute_off.svg";
+		masterMute.src = "svg/mute_off.svg";
 	}
 
 	// fix volume container
@@ -346,10 +347,10 @@ function renderQueue(queue) {
 		li.tabIndex = trackIndex;
 
 		var albumArt = document.createElement('img');
-		//albumArt.src = q.albumArtURI;
-		albumArt.dataset.src = q.albumArtURI;
+		var prefix = (window.location.pathname != '/') ? window.location.pathname : ''
+		albumArt.dataset.src = prefix + q.albumArtURI;
 		if (trackIndex < 20) {
-			albumArt.src = q.albumArtURI;
+			albumArt.src = prefix + q.albumArtURI;
 			albumArt.className = "loaded";
 		}
 

--- a/static/js/socket.js
+++ b/static/js/socket.js
@@ -5,7 +5,8 @@
 
 var Socket = Socket || {};
 
-Socket.socket = io.connect('/');
+var target = window.location.protocol + '//' + window.location.hostname + ':8080';
+Socket.socket = io.connect(target);
 
 Socket.socket.on('topology-change', function (data) {
 	Sonos.grouping = {};

--- a/static/spotify/index.html
+++ b/static/spotify/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<link rel="stylesheet" type="text/css" href="/css/common.css" />
 		<link rel="stylesheet" type="text/css" href="css/spotify.css" />
-		<script src="/socket.io/socket.io.js"></script>
+		<script src="socket.io/socket.io.js"></script>
 		<script>
 		  var socket = io.connect('/');
 		</script>


### PR DESCRIPTION
This makes it possible to run behind proxy, like nginx, on default port, ie `https://homeserver/sonos/`, instead of `http://homeserver:8080`.

Handling of the album cover absolute URL (`/getaa?`) is somewhat iffy, but seems to work.

Sample nginx config:
```nginx
location /sonos {
  rewrite ^/sonos/(.*) /$1 break;
  proxy_pass http://localhost:8080;
  proxy_set_header X-Real-IP $remote_addr;
  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
  proxy_set_header Host $http_host;
  proxy_set_header X-Forwarded-Proto https;
  proxy_redirect off;
}
```
```