### PR TITLE
Fix: Exception in group-volume handler when calling groupSetVolume()

### DIFF
--- a/server.js
+++ b/server.js
@@ -138,7 +138,7 @@ socketServer.sockets.on('connection', function (socket) {
     if (!player) return;
 
     // invoke action
-    copns.groupSetVolume(data.volume);
+    player.groupSetVolume(data.volume);
   });
 
   socket.on('group-management', function (data) {


### PR DESCRIPTION
I did not find 'copns', so I changed this to 'player'. Now groupSetVolume() works.